### PR TITLE
Default lengths to 0.0

### DIFF
--- a/src/stream.rs
+++ b/src/stream.rs
@@ -551,7 +551,7 @@ impl<'a> Stream<'a> {
     pub fn parse_length(&mut self) -> Result<Length> {
         self.skip_spaces();
 
-        let n = self.parse_number()?;
+        let n = self.parse_number().unwrap_or(0.0);
 
         if self.at_end() {
             return Ok(Length::new(n, LengthUnit::None));


### PR DESCRIPTION
I don't think this is the best way to achieve this, since it will default to 0.0 no matter what caused the `invalid number`, but I'm more concerned with the approach rather than the implementation at the moment.

We're using resvg and have a few SVGs that are failing with it due to having attributes with empty string values. Here's an example SVG I've created describing such
[example.svg.zip](https://github.com/RazrFalcon/svgtypes/files/4347054/example.svg.zip)

I've tried it on both Chrome and Firefox and they seem to treat these values (at least for this case) as 0.0. Resvg will on the other hand error on this svg. I'm not too familiar with the SVG 1.1 spec myself, but I think having a default value for empty string attributes is appropriate.