### PR TITLE
Fix a warning in unnecessary explicit borrow

### DIFF
--- a/src/colors.rs
+++ b/src/colors.rs
@@ -196,7 +196,6 @@ pub fn from_str(text: &str) -> Option<Color> {
 //
 // https://github.com/sfackler/rust-phf
 
-use std::borrow::Borrow;
 use std::hash::Hasher;
 
 pub struct Map<V: 'static> {
@@ -210,8 +209,7 @@ impl<V> Map<V> {
         let hash = hash(key, self.key);
         let index = get_index(hash, self.disps, self.entries.len());
         let entry = &self.entries[index as usize];
-        let b = entry.0.borrow();
-        if b == key {
+        if entry.0 == key {
             Some(&entry.1)
         } else {
             None


### PR DESCRIPTION
This simplifies the code a bit.