### PR TITLE
fix: Allow ascii characters in font families

### DIFF
--- a/src/font.rs
+++ b/src/font.rs
@@ -63,7 +63,7 @@ impl<'a> Stream<'a> {
 
                     while let Some(c) = self.chars().next() {
                         if c != ',' {
-                            idents.push(self.parse_ident()?.to_string());
+                            idents.push(self.consume_ascii_ident().to_string());
                             self.skip_spaces();
                         } else {
                             break;


### PR DESCRIPTION
It is valid and possible for font family name to contain alphanumeric characters. Example: any static Inter font in google font contains "24pt" / "18pt" in family name https://fonts.google.com/specimen/Inter